### PR TITLE
test:react-native-nested-dndの導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@react-navigation/native": "^6.0.2",
     "@react-navigation/native-stack": "^6.1.0",
     "@types/react-native-dotenv": "^0.2.0",
+    "add": "^2.0.6",
     "date-fns": "^2.28.0",
     "expo": "^43.0.0",
     "expo-asset": "~8.4.3",
@@ -67,6 +68,7 @@
     "react-native-gesture-handler": "~1.10.2",
     "react-native-modal": "^13.0.1",
     "react-native-modal-datetime-picker": "^13.0.1",
+    "react-native-nested-dnd": "^1.1.2",
     "react-native-paper": "3.6.0",
     "react-native-progress": "^5.0.0",
     "react-native-reanimated": "2",
@@ -77,7 +79,8 @@
     "react-native-vector-icons": "^9.0.0",
     "react-native-web": "0.17.1",
     "react-native-webview": "11.13.0",
-    "rn-bounceable": "^1.1.0"
+    "rn-bounceable": "^1.1.0",
+    "yarn": "^1.22.17"
   },
   "devDependencies": {
     "@babel/core": "7.16.0",

--- a/src/components/screen/Todo/DnDSample.tsx
+++ b/src/components/screen/Todo/DnDSample.tsx
@@ -1,0 +1,128 @@
+import type { FC } from "react";
+import React, { useState } from "react";
+import { Dimensions, StyleSheet } from "react-native";
+import NestedDND from "react-native-nested-dnd/NestedDND";
+
+import { TodoItem } from "~/components/model/todo/TodoItem";
+import { Text } from "~/components/ui/Text";
+import { View } from "~/components/ui/View";
+
+import type { TodoScreenProps } from "./ScreenProps";
+
+const SAMPLE_DATA = [
+  {
+    id: "TODAY",
+    title: "今日する",
+    color: "primary",
+    items: [
+      { id: 1, title: "React勉強", category: "TODAY" },
+      { id: 2, title: "Svelte勉強", category: "TODAY" },
+      { id: 3, title: "Angular勉強", category: "TODAY" },
+      { id: 4, title: "Vue勉強", category: "TODAY" },
+      { id: 5, title: "Next.js勉強", category: "TODAY" },
+      { id: 6, title: "Remix勉強", category: "TODAY" },
+    ],
+  },
+  {
+    id: "TOMORROW",
+    title: "明日する",
+    color: "secondary",
+    items: [
+      { id: 7, title: "Python勉強", category: "TOMORROW" },
+      { id: 8, title: "Go勉強", category: "TOMORROW" },
+      { id: 9, title: "Java勉強", category: "TOMORROW" },
+      { id: 10, title: "Ruby勉強", category: "TOMORROW" },
+      { id: 11, title: "PHP勉強", category: "TOMORROW" },
+      { id: 12, title: "Rust勉強", category: "TOMORROW" },
+    ],
+  },
+  {
+    id: "SOMEDAY",
+    title: "今度する",
+    color: "tertiary",
+    items: [
+      { id: 13, title: "Figma勉強", category: "SOMEDAY" },
+      { id: 14, title: "Docker勉強", category: "SOMEDAY" },
+      { id: 15, title: "Notion勉強", category: "SOMEDAY" },
+      { id: 16, title: "Prisma勉強", category: "SOMEDAY" },
+    ],
+  },
+] as const;
+
+type SampleDataProps = typeof SAMPLE_DATA[number];
+
+const RenderItem: FC<SampleDataProps["items"][number]> = (props) => {
+  return (
+    <View style={style.item_wrap}>
+      <TodoItem status={props.category} title={props.title} />
+    </View>
+  );
+};
+
+const RenderGroupHeader: FC<SampleDataProps> = (props) => {
+  return (
+    <View style={style.item_wrap}>
+      <Text style={style.category_label} color={props.color}>
+        {props.title}
+      </Text>
+    </View>
+  );
+};
+
+const RenderHeader = () => {
+  return <View style={style.bottom_space} />;
+};
+
+const headerHeight = 20;
+const groupToItemsKey = "items"; // データレコードのkey
+const keyExtractor = (props: SampleDataProps) => props.id; // keyを指定（group,data共通）
+
+export const DnDSample: FC<TodoScreenProps> = () => {
+  const [groups, setGroups] = useState(SAMPLE_DATA);
+
+  return (
+    <View style={style.container}>
+      <NestedDND
+        groups={groups}
+        updateGroups={setGroups}
+        groupToItemsKey={groupToItemsKey}
+        groupKeyExtractor={keyExtractor}
+        itemKeyExtractor={keyExtractor}
+        ghostStyle={style.ghostStyle}
+        movedWrapStyle={style.movingStyle}
+        renderItem={RenderItem}
+        renderGroupHeader={RenderGroupHeader}
+        renderBottomView={RenderHeader()}
+        headerViewHeight={headerHeight}
+        bottomViewHeight={headerHeight}
+      />
+    </View>
+  );
+};
+
+const style = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingBottom: 50,
+    flexDirection: "column",
+  },
+  item_wrap: {
+    paddingHorizontal: "3%",
+    width: Dimensions.get("window").width,
+  },
+  category_label: {
+    fontSize: 24,
+    fontWeight: "600",
+    marginVertical: "4%",
+    paddingLeft: "2%",
+  },
+  ghostStyle: {
+    opacity: 0.4,
+  },
+  movingStyle: {
+    opacity: 0,
+  },
+  bottom_space: {
+    height: 150,
+  },
+});

--- a/src/components/screen/Todo/Todo.screen.tsx
+++ b/src/components/screen/Todo/Todo.screen.tsx
@@ -7,15 +7,15 @@ import { KeyboardAvoiding } from "~/components/functional/KeyboardAvoiding";
 import { TodoInput } from "~/components/model/todo/TodoInput";
 import { SafeAreaLayout } from "~/components/ui/Layout";
 
+import { DnDSample } from "./DnDSample";
 import type { TodoScreenProps } from "./ScreenProps";
-import { Todo } from "./Todo";
 
 export const TodoScreen: FC<TodoScreenProps> = (props) => {
   return (
     <LayoutErrorBoundary>
       <SafeAreaLayout bg="bg1">
         <KeyboardAvoiding>
-          <Todo {...props} />
+          <DnDSample {...props} />
         </KeyboardAvoiding>
 
         <InputAccessoryView>

--- a/src/types/react-native-nested-dnd.d.ts
+++ b/src/types/react-native-nested-dnd.d.ts
@@ -1,0 +1,1 @@
+declare module "react-native-nested-dnd/NestedDND";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,6 +2405,11 @@ acorn@^8.7.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -8433,6 +8438,11 @@ react-native-dotenv@^3.3.0:
   dependencies:
     dotenv "^10.0.0"
 
+react-native-drag-sort-cr@~2.7.3:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/react-native-drag-sort-cr/-/react-native-drag-sort-cr-2.7.3.tgz#a7626750c5d6bd0d02ee46b9f4042647a619ea4e"
+  integrity sha512-j9cXgX1OPKRcRCIXP9kaRdgjSkMNmICjJ1q1DjST1ZBHSgZsbo/EIv4zcuXoAgReInDKwtFFu3hiZMg7uX0t7g==
+
 react-native-elements@^3.4.2:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-3.4.2.tgz#66602be9c5e0e0a2a831913adec80ff6518d1ee2"
@@ -8472,6 +8482,13 @@ react-native-modal@^13.0.1:
   dependencies:
     prop-types "^15.6.2"
     react-native-animatable "1.3.3"
+
+react-native-nested-dnd@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-nested-dnd/-/react-native-nested-dnd-1.1.2.tgz#6e346ee81a4860adc09505b2a332273f55f6dd87"
+  integrity sha512-LDLL6a/DIDOdhsc2UPDmBs53SCdNz3RP3Kb6Sz7a2lgVfwfCxgEZJUP09zghzcCWkkVhadlmBNdMUS+HRKYfoQ==
+  dependencies:
+    react-native-drag-sort-cr "~2.7.3"
 
 react-native-paper@3.6.0:
   version "3.6.0"
@@ -10458,6 +10475,11 @@ yargs@^17.0.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yarn@^1.22.17:
+  version "1.22.17"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.17.tgz#bf910747d22497b573131f7341c0e1d15c74036c"
+  integrity sha512-H0p241BXaH0UN9IeH//RT82tl5PfNraVpSpEoW+ET7lmopNC61eZ+A+IDvU8FM6Go5vx162SncDL8J1ZjRBriQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
close #7 

ちょっと挙動が怪しくもあるが一応動作しましたので一旦プルリク。

**変更点**
- サンプルを [src/components/screen/Todo/DnDSample.tsx](https://github.com/do-it-if-i-can/native-mobile/compare/test/react-native-nested-dnd?expand=1#diff-9c1d7ecd030c3528e224b97e89f0a2b7f8d70025054b086521b559293845a97e) に実装してます。


**気づき**
- 動きが遅い。アニメーションが遅いのかパッケージ自体が重いのかよくわかりません
- reanimatedのv2で意外と動いた。
- ドロップエリア外に持っていくとエラー吐いてしまう

**新たな課題**
- アプリ全体でreanimatedのv1使うかv2使うかも検討（v1のパッケージが多い気がした、現在v2系が入ってる）


https://user-images.githubusercontent.com/71614432/157180234-6e379882-dc8d-4929-9bdf-9132ca21d2a7.mp4



 