### PR TITLE
fix:モーダル開閉時にInputAccessoryViewが表示されなくなるバグ

### DIFF
--- a/src/components/screen/Todo/Todo.screen.tsx
+++ b/src/components/screen/Todo/Todo.screen.tsx
@@ -1,26 +1,32 @@
 import type { FC } from "react";
 import React from "react";
 import { InputAccessoryView } from "react-native";
+import { useRecoilValue } from "recoil";
 
 import { LayoutErrorBoundary } from "~/components/functional/Error";
 import { KeyboardAvoiding } from "~/components/functional/KeyboardAvoiding";
 import { TodoInput } from "~/components/model/todo/TodoInput";
 import { Layout } from "~/components/ui/Layout";
+import { inputAccessoryIsVisible } from "~/stores/inputAccessoryIsVisible";
 
 import { DnDSample } from "./DnDSample";
 import type { TodoScreenProps } from "./ScreenProps";
 
 export const TodoScreen: FC<TodoScreenProps> = (props) => {
+  const inputAccessory = useRecoilValue(inputAccessoryIsVisible);
+
   return (
     <LayoutErrorBoundary>
-      <Layout safeArea="horizontal" bg="bg1">
+      <Layout safeArea="bottom-horizontal" bg="bg1">
         <KeyboardAvoiding>
           <DnDSample {...props} />
         </KeyboardAvoiding>
 
-        <InputAccessoryView>
-          <TodoInput />
-        </InputAccessoryView>
+        {inputAccessory.isVisible ? (
+          <InputAccessoryView>
+            <TodoInput />
+          </InputAccessoryView>
+        ) : null}
       </Layout>
     </LayoutErrorBoundary>
   );

--- a/src/screens/main/setting/index.tsx
+++ b/src/screens/main/setting/index.tsx
@@ -1,8 +1,9 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { FC } from "react";
-import React from "react";
+import React, { useEffect } from "react";
+import { useSetRecoilState } from "recoil";
 
-import { Toaster } from "~/components/ui/Toaster";
+import { inputAccessoryIsVisible } from "~/stores/inputAccessoryIsVisible";
 import type { SettingStackParamList } from "~/types";
 
 import { AccountScreen } from "./account.screen";
@@ -13,16 +14,19 @@ import { ThemeScreen } from "./theme.screen";
 const SettingStack = createNativeStackNavigator<SettingStackParamList>();
 
 export const SettingNavigator: FC = () => {
-  return (
-    <>
-      <SettingStack.Navigator initialRouteName="SettingScreen" screenOptions={{ headerShown: false }}>
-        <SettingStack.Screen name="SettingScreen" component={SettingScreen} />
-        <SettingStack.Screen name="AccountScreen" component={AccountScreen} />
-        <SettingStack.Screen name="ProfileScreen" component={ProfileScreen} />
-        <SettingStack.Screen name="ThemeScreen" component={ThemeScreen} />
-      </SettingStack.Navigator>
+  const setIsVisible = useSetRecoilState(inputAccessoryIsVisible);
 
-      <Toaster />
-    </>
+  useEffect(() => {
+    setIsVisible({ isVisible: false });
+    return () => setIsVisible({ isVisible: true });
+  }, [setIsVisible]);
+
+  return (
+    <SettingStack.Navigator initialRouteName="SettingScreen" screenOptions={{ headerShown: false }}>
+      <SettingStack.Screen name="SettingScreen" component={SettingScreen} />
+      <SettingStack.Screen name="AccountScreen" component={AccountScreen} />
+      <SettingStack.Screen name="ProfileScreen" component={ProfileScreen} />
+      <SettingStack.Screen name="ThemeScreen" component={ThemeScreen} />
+    </SettingStack.Navigator>
   );
 };

--- a/src/stores/inputAccessoryIsVisible.ts
+++ b/src/stores/inputAccessoryIsVisible.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+export const inputAccessoryIsVisible = atom({
+  key: "inputAccessoryIsVisible",
+  default: {
+    isVisible: true,
+  },
+});


### PR DESCRIPTION
close #20 

> InputAccessoryViewとはキーボードの上部にViewを持たせることができるものです。
本来はTextInputとInputAccessoryViewに同じIDを持たせることで、そのTextInputの入力時に任意のInputAccessoryViewを表示させることができます。今回は画面下部にTextInputを常時表示させる必要があるので、InputAccessoryView自体にIDを持たせないことで実現できます。

**変更点**
状態管理で `isVIsible` というstateを持たせて、モーダルのマウント時アンマウント時にトグルさせて再レンダリングをしてあげることで解決できました。

[👉 参考記事](https://stackoverflow.com/questions/59156706/react-native-ios-inputaccessoryview-disappear-from-the-screen-after-close-modal#:~:text=%E3%81%93%E3%82%8C%E3%81%A7%E8%A9%A6%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82InputAccessoryView%E3%83%A2%E3%83%BC%E3%83%80%E3%83%AB%E3%81%8C%E9%96%89%E3%81%98%E3%81%9F%E3%82%89%E5%86%8D%E3%83%AC%E3%83%B3%E3%83%80%E3%83%AA%E3%83%B3%E3%82%B0%E3%81%97%E3%81%BE%E3%81%99)

https://user-images.githubusercontent.com/71614432/157937617-2ef2ad34-9086-4716-b212-b7e559630f98.mp4

